### PR TITLE
Add option to disable auto-expanded panel on page load

### DIFF
--- a/content/shared.js
+++ b/content/shared.js
@@ -144,6 +144,8 @@ function getPanelLocaleText() {
             preferencesLabel: 'Préférences',
             backLabel: '← Retour',
             preferencesIntro: '',
+            expandPanelOnPageLoadLabel: 'Déplier le panneau à l’ouverture de la page',
+            expandPanelOnPageLoadTooltip: 'Si cette option est désactivée, le panneau reste replié en bas à droite à chaque chargement de page (sauf la toute première visite).',
             darkModeLabel: 'Mode sombre',
             darkModeTooltip: 'Active un thème sombre pour 2ememain et le panneau Cleanplaats. Expérimental: si la visibilité pose problème, désactivez-le.',
             resultsPerPageLabel: 'Résultats par page :',
@@ -228,6 +230,8 @@ function getPanelLocaleText() {
         preferencesLabel: 'Voorkeuren',
         backLabel: '← Terug',
         preferencesIntro: '',
+        expandPanelOnPageLoadLabel: 'Paneel uitklappen bij openen pagina',
+        expandPanelOnPageLoadTooltip: 'Uit: het paneel start bij elke pagina ingeklapt (behalve de allereerste keer). Aan: onthoudt of het paneel uit- of ingeklapt was.',
         darkModeLabel: 'Donkere modus',
         darkModeTooltip: 'Schakelt een donker thema in voor Marktplaats en het Cleanplaats-paneel. Experimenteel: werkt meestal goed, maar zet het uit als iets slecht leesbaar is.',
         resultsPerPageLabel: 'Resultaten per pagina:',
@@ -290,7 +294,8 @@ var CLEANPLAATS = {
         blacklistedTerms: [],
         resultsPerPage: 30,
         defaultSortMode: 'standard',
-        sortPreferenceSource: 'cleanplaats'
+        sortPreferenceSource: 'cleanplaats',
+        expandPanelOnPageLoad: false
     },
 
     stats: {

--- a/content/ui.js
+++ b/content/ui.js
@@ -2,8 +2,23 @@
  * Content-script control panel rendering and UI event handling.
  */
 
+function applyInitialPanelStateForPageLoad() {
+    if (CLEANPLAATS.featureFlags.firstRun) {
+        CLEANPLAATS.panelState.isCollapsed = false;
+        CLEANPLAATS.panelState.activeView = 'filters';
+        return;
+    }
+
+    if (!CLEANPLAATS.settings.expandPanelOnPageLoad) {
+        CLEANPLAATS.panelState.isCollapsed = true;
+        CLEANPLAATS.panelState.activeView = 'filters';
+    }
+}
+
 function createControlPanel() {
     if (document.getElementById('cleanplaats-panel')) return;
+
+    applyInitialPanelStateForPageLoad();
 
     const panel = document.createElement('div');
     panel.id = 'cleanplaats-panel';
@@ -237,6 +252,18 @@ function createControlPanel() {
                     ` : ''}
                 </div>
                 <div class="cleanplaats-options">
+                    <div class="cleanplaats-option cleanplaats-option-preference">
+                        <label class="cleanplaats-switch">
+                            <input type="checkbox" id="expandPanelOnPageLoad" ${CLEANPLAATS.settings.expandPanelOnPageLoad ? 'checked' : ''}>
+                            <span class="cleanplaats-switch-slider"></span>
+                        </label>
+                        <label for="expandPanelOnPageLoad" class="cleanplaats-option-label">
+                            <span class="cleanplaats-option-label-text">
+                                ${panelText.expandPanelOnPageLoadLabel}
+                                <span class="cleanplaats-tooltip-icon" data-tooltip="${panelText.expandPanelOnPageLoadTooltip}">?</span>
+                            </span>
+                        </label>
+                    </div>
                     <div class="cleanplaats-option cleanplaats-option-preference">
                         <label class="cleanplaats-switch">
                             <input type="checkbox" id="removeFavoriteRelatedAds" ${CLEANPLAATS.settings.removeFavoriteRelatedAds ? 'checked' : ''}>
@@ -682,7 +709,7 @@ function setupEventListeners() {
     });
 
     ['removeTopAds', 'removeDagtoppers', 'removePromotedListings',
-        'removeOpvalStickers', 'removeReservedListings', 'removeFavoriteRelatedAds', 'sellerAgeWarningEnabled'].forEach(id => {
+        'removeOpvalStickers', 'removeReservedListings', 'expandPanelOnPageLoad', 'removeFavoriteRelatedAds', 'sellerAgeWarningEnabled'].forEach(id => {
         const checkbox = document.getElementById(id);
         if (checkbox) {
             checkbox.addEventListener('change', handleCheckboxChange);
@@ -744,6 +771,11 @@ function handleCheckboxChange(event) {
         .then(() => {
             if (setting === 'darkMode') {
                 applyDarkModeToDocument(value);
+                showSettingFeedback();
+                return;
+            }
+
+            if (setting === 'expandPanelOnPageLoad') {
                 showSettingFeedback();
                 return;
             }


### PR DESCRIPTION
## Summary

The Cleanplaats panel in the bottom-right corner opened **fully expanded on every page load** for most users (default `isCollapsed: false`). That can feel intrusive, especially when the last session ended on the **Voorkeuren** tab—so the "settings" view reappeared on each visit.

This PR adds a **Voorkeuren** toggle: **Paneel uitklappen bij openen pagina** (`expandPanelOnPageLoad`, default **off**).

### Behavior

| Situation | Result |
|-----------|--------|
| **First visit** (first run) | Panel is **expanded** once on the **Filters** view so new users notice the extension. |
| **Later visits**, preference **off** (default) | Panel starts **collapsed**; active tab is **Filters** so Voorkeuren does not reopen automatically. |
| Preference **on** | Previous behavior: **respect persisted** collapsed/expanded state across visits. |

### Implementation notes

- `applyInitialPanelStateForPageLoad()` runs at the start of `createControlPanel()` after `loadSettings()`.
- Stored `panelState` is still updated when the user collapses/expands during a session; the new setting only affects **initial** render when the preference is off.
- French (2ememain) and Dutch copy included for the new control and tooltip.
- No background script changes; setting lives in existing `cleanplaatsSettings` JSON.

### How to test

1. Reset or use a fresh profile: first Marktplaats/2dehands load → panel expanded, filters tab.
2. Reload or navigate: panel should start **collapsed** by default.
3. Enable **Paneel uitklappen bij openen pagina**, collapse/expand, reload → state should **persist** as before.
4. With preference off, expand panel, reload → should start **collapsed** again.

---

Fork PR: `Acetyld/Cleanplaats` → `Aron220/Cleanplaats`.

Made with [Cursor](https://cursor.com)